### PR TITLE
Present the ImageScannerController modally to prevent invisible nav bar

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   barcode:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.5"
+    version: "0.2.6"
   fake_async:
     dependency: transitive
     description:
@@ -157,14 +157,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   numberpicker:
     dependency: transitive
     description:
@@ -178,7 +178,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_parsing:
     dependency: transitive
     description:
@@ -248,7 +248,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.1"
+    version: "0.12.0"
   platform:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sqflite:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -372,7 +372,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -395,5 +395,5 @@ packages:
     source: hosted
     version: "5.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.24.0-10"

--- a/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
+++ b/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
@@ -4,7 +4,7 @@ import UIKit
 
 public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
     
-    var rootViewController: UIViewController?
+    var rootViewController: UIViewController?
     var result: FlutterResult?
     
     
@@ -12,6 +12,8 @@ public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
         super.init()
         rootViewController =
             (UIApplication.shared.delegate?.window??.rootViewController)!;
+        navigationController = rootViewController.navigationController
+        navigationController?.navigationBar.barTintColor = UIColor.blue
     }
     
     public static func register(with registrar: FlutterPluginRegistrar) {

--- a/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
+++ b/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
@@ -12,8 +12,6 @@ public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
         super.init()
         rootViewController =
             (UIApplication.shared.delegate?.window??.rootViewController)!;
-        navigationController = rootViewController.navigationController
-        navigationController?.navigationBar.barTintColor = UIColor.blue
     }
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -36,10 +34,11 @@ public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
         
     }
     
-    private func camera(){
+    private func camera() {
         let scannerViewController: ImageScannerController = ImageScannerController()
         scannerViewController.imageScannerDelegate = self
-        
+        scannerViewController.modalPresentationStyle = .fullScreen
+
         rootViewController?.present(scannerViewController, animated:true, completion:nil)
     }
     
@@ -47,6 +46,8 @@ public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
         let imagePicker = UIImagePickerController()
         imagePicker.delegate = self
         imagePicker.sourceType = .photoLibrary
+        imagePicker.modalPresentationStyle = .fullScreen
+
         rootViewController?.present(imagePicker, animated: true)
     }
 }

--- a/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
+++ b/ios/Classes/SwiftDocumentScannerFlutterPlugin.swift
@@ -39,6 +39,10 @@ public class SwiftDocumentScannerFlutterPlugin: NSObject, FlutterPlugin {
         scannerViewController.imageScannerDelegate = self
         scannerViewController.modalPresentationStyle = .fullScreen
 
+        if #available(iOS 13.0, *) {
+            scannerViewController.overrideUserInterfaceStyle = .dark
+        }
+
         rootViewController?.present(scannerViewController, animated:true, completion:nil)
     }
     

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   barcode:
     dependency: transitive
     description:
@@ -35,14 +35,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -108,21 +108,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_parsing:
     dependency: transitive
     description:
@@ -185,7 +185,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.1"
+    version: "0.12.0"
   platform:
     dependency: transitive
     description:
@@ -225,7 +225,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -274,7 +274,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -297,5 +297,5 @@ packages:
     source: hosted
     version: "5.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: document_scanner_flutter
 description: A android & ios document scanner & auto detector plugin for flutter.
-version: 0.2.5
+version: 0.2.6
 homepage: https://github.com/ishaquehassan/document_scanner_flutter
 
 environment:


### PR DESCRIPTION
This fixes an issue when presenting the `ImageScannerController` modally. The partial takeover has a transparent nav bar and therefore you can see the `UINavigationController` underneath and the `UIBarButtonItem`s are not clearly visible.

By presenting the view controllers with fullscreen modal presentation style, the nav bar is forced black and the text is legible

## Screenshot

### Before

![IMG_1831](https://user-images.githubusercontent.com/521845/147610374-96950cda-b058-45c2-9dab-eefa2a7ffead.PNG)

### After

![IMG_1832](https://user-images.githubusercontent.com/521845/147610403-2eb0ca28-8c27-4442-a3c3-cec466b09e8a.PNG)
![IMG_1833](https://user-images.githubusercontent.com/521845/147610412-7f53a02c-acd6-4357-8c91-095534696bab.PNG)
![IMG_1834](https://user-images.githubusercontent.com/521845/147610417-b0dd5d7e-99f1-4c3e-9cf4-419135e05646.PNG)
